### PR TITLE
bash -> sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Run Composer install.
 composer install


### PR DESCRIPTION
Changing bash -> sh since in some distro bash is link of /bin/sh (slightly faster too).
